### PR TITLE
Remove counting of linebreaks in 50 char rule

### DIFF
--- a/lib/poper/rule/fifty_char_summary.rb
+++ b/lib/poper/rule/fifty_char_summary.rb
@@ -4,7 +4,7 @@ module Poper
       MSG = 'Git commit message summary (first line) should be 50 chars or less'
 
       def check(message)
-        MSG if message.lines.first.length > 50
+        MSG if message.lines.first.chomp.length > 50
       end
     end
   end


### PR DESCRIPTION
Hi Folks,

We've found out that poper threw the 'Git commit message summary (first line) should be 50 chars or less' even though we made sure *not* to exceed the 50 chars.
A view into the source revealed that line breaks (such as before a commit summary) are counted as well.
So we suggest this little fix to this issue.
Let me know, what you think...

Cheers

Originally found by mbreit :)