### PR TITLE
config_file.rb bugfix

### DIFF
--- a/lib/poper/config_file.rb
+++ b/lib/poper/config_file.rb
@@ -38,7 +38,7 @@ module Poper
         if oldval.is_a?(Hash) && newval.is_a?(Hash)
           oldval.merge(newval, &merger)
         else
-          oldval || newval
+          oldval.nil? ? newval : oldval
         end
       end
 

--- a/spec/poper/config_file_spec.rb
+++ b/spec/poper/config_file_spec.rb
@@ -74,6 +74,28 @@ module Poper
           )
         end
       end
+      context 'a value is set to false' do
+        before do
+          File.should_receive(:exist?)
+            .and_return(true)
+
+          YAML.should_receive(:load_file)
+            .and_return('summary_character_limit' => {
+                'enabled' => false,
+                'number' => 95
+              }
+            )
+        end
+
+        it do
+          should include(
+             'summary_character_limit' => {
+               'enabled' => false,
+               'number' => 95
+             }
+           )
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Added bugfix for not taking config params that are set to false.
Added test to ensure change works.

Issue:
When adding the below to the .poper.yml the warnings still appear, this pr fixes this issue.
```
character_limit:
  enabled: false
summary_character_limit:
  enabled: false
```