### PR TITLE
Relax dependency versioning for thor and rugged

### DIFF
--- a/lib/poper/version.rb
+++ b/lib/poper/version.rb
@@ -1,3 +1,3 @@
 module Poper
-  VERSION = '0.2.1'.freeze
+  VERSION = '0.2.2'.freeze
 end

--- a/poper.gemspec
+++ b/poper.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.executables << 'poper'
 
-  s.add_runtime_dependency('rugged', '~> 0.23', '>= 0.23.0')
-  s.add_runtime_dependency('thor', '~> 0.19.0')
+  s.add_runtime_dependency('rugged', '~> 0.23')
+  s.add_runtime_dependency('thor', '~> 0.19')
   s.add_development_dependency('rake', '~> 12.0')
   s.add_development_dependency('rspec', '~> 3.4')
   s.add_development_dependency('rspec-its', '~> 1.2')


### PR DESCRIPTION
`~> 0.19` effectively means:
```
  < 1.0
  >= 0.19
```