### PR TITLE
Do not count line endings toward character limit

### DIFF
--- a/lib/poper/rule/character_limit.rb
+++ b/lib/poper/rule/character_limit.rb
@@ -3,7 +3,7 @@ module Poper
     class CharacterLimit < Rule
       def check(message)
         error_message if message.lines.any? do |line|
-          line.length > character_limit
+          line.chomp.length > character_limit
         end
       end
 

--- a/spec/poper/rule/character_limit_spec.rb
+++ b/spec/poper/rule/character_limit_spec.rb
@@ -17,7 +17,39 @@ Write your commit message in the imperative: "Fix bug", not "Fixed bug"'
           it { should be_nil }
         end
 
+        context 'seventy-two char line' do
+          let(:message) do
+            'Implement that feature - really really really well
+
+Write your commit message in the imperative: "Fix bug", not "Fixed bug"!
+More text here!'
+          end
+
+          it { should be_nil }
+        end
+
+        context 'seventy-two char last line' do
+          let(:message) do
+            'Implement that feature - really really really well
+
+Write your commit message in the imperative: "Fix bug", not "Fixed bug"!'
+          end
+
+          it { should be_nil }
+        end
+
         context 'seventy-three char line' do
+          let(:message) do
+            'Implement that feature - really really really well
+
+Write your commit message in the imperative: "Fix bugs", not "Fixed bugs"
+More text here!'
+          end
+
+          it { should_not be_nil }
+        end
+
+        context 'seventy-three char last line' do
           let(:message) do
             'Implement that feature - really really really well
 


### PR DESCRIPTION
With the existing implementation, poper would incorrectly flag lines that have exactly 72 character but are followed by a newline.

This pull request
- Adds specs to test the case of exactly 72 characters;
- Adds specs so the case where the long line is followed by a newline is tested.
- Amends the CharacterLimit rule to remove line endings from the message lines.