### PR TITLE
Fix mmozuras/poper#15 (Pin rugged version to 0.23.X)

### DIFF
--- a/poper.gemspec
+++ b/poper.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.executables << 'poper'
 
-  s.add_runtime_dependency('rugged', '~> 0.23', '>= 0.23.0')
+  s.add_runtime_dependency('rugged', '~> 0.23.0')
   s.add_runtime_dependency('thor', '~> 0.20.0')
   s.add_development_dependency('bundler', '>= 1.10')
   s.add_development_dependency('codeclimate-test-reporter', '~> 1.0')


### PR DESCRIPTION
**The problem:**

https://github.com/mmozuras/poper/issues/15

The test suite currently fails because of incompatibilities in version `0.99.0` of the `rugged` dependency. The dependency should be pinned to an older version to ensure compatibility.

**The approach:**

Currently, the gemspec uses [~>](https://thoughtbot.com/blog/rubys-pessimistic-operator) to set the version of the `rugged` dependency above `0.23`.

This operator actually allows the final sequence of digits in the version string to increment to whatever is the most recent minor version release. In this case, `0.99.0` is the most recent version of `rugged`, so the `23` gets incremented to `99` during `bundle install`.

Adding an additional sub-version to the version string allows only the final `0` to be incremented. In this case, the most recent `rugged 0.23.X` sub-version is `0.23.3`, which is compatible with `poper` and will allow the test suite to pass.