### PR TITLE
Workaround regression in recent rugged versions

### DIFF
--- a/lib/poper/runner.rb
+++ b/lib/poper/runner.rb
@@ -32,7 +32,7 @@ module Poper
     def commits
       @commits ||= begin
         walker.reset
-        walker.push(@repo.last_commit)
+        walker.push(@repo.last_commit.oid)
         walker.take_while { |c| c.oid != @commit.oid } << @commit
       end
     end


### PR DESCRIPTION
Recent versions of rugged are not accepting Rugged::Commit as an
argument to Rugged::Walker#push. We can workaround this by passing
string oid.

Closes #15
Refs. https://github.com/libgit2/rugged/issues/860
